### PR TITLE
Add check for SystemRequirements,

### DIFF
--- a/bioconda_utils/bioconductor_skeleton.py
+++ b/bioconda_utils/bioconductor_skeleton.py
@@ -448,6 +448,17 @@ class BioCProjectPage(object):
             return []
 
     @property
+    def systemrequirements(self):
+        """
+        List of "SystemRequirements" from the VIEW file
+        """
+        try:
+            print(self.packages[self.package]['SystemRequirements'])
+            return self.packages[self.package]['SystemRequirements']
+        except KeyError:
+            return []
+
+    @property
     def depends(self):
         """
         List of "depends" from the VIEW file
@@ -584,6 +595,15 @@ class BioCProjectPage(object):
 
             else:
                 dependency_mapping[prefix + name.lower() + version] = name
+
+        # Check SystemRequirements in the DESCRIPTION file to make sure
+        # packages with such reqquirements are provided correct recipes.
+        if (self.packages[self.package].get('SystemRequirements') is not None):
+            logger.warning(
+                "The 'SystemRequirements' {} are needed".format(
+                    self.packages[self.package].get('SystemRequirements')) +
+                " by the recipe for the package to work as intended."
+            )
 
         if (
             (self.packages[self.package].get('NeedsCompilation', 'no') == 'yes') or


### PR DESCRIPTION
SystemRequirements in the DESCRIPTION file provide dependencies
which are usually not fulfilled by the bioconductor-skeleton.py.

These usually represent external dependencies.

Take for instance the package 'rsbml', which has the SystemRequirement,
libsbml (==5.10.2). This is not fulfilled by this script, and should
throw a warning to the user that there is a recipe for libsbml is also
needed.

There are many packages which have such SystemRequirements with
Bioconductor, as shown in this gist.

    https://gist.github.com/nturaga/39185116b8681264e7405b868e00d405

If there are suggestions from the Bioconda team to standardizing the format of
SystemRequirements, I could try to get them standardized across
Bioconductor packages, so we have a better chance of fulfilling them
automatically.

I'm cc-ing @mtmorgan, and @vobencha to help answer add context if
needed.

The PR leaves an output like this,

```
(base) ~/D/bioconda-recipes ❯❯❯ bioconda-utils bioconductor-skeleton recipes config.yml rsbml
15:08:36 BIOCONDA INFO Making recipe for: rsbml
15:08:36 BIOCONDA DEBUG rsbml==2.40.0, BioC==3.8
15:08:37 BIOCONDA INFO Using tarball from https://bioconductor.org/packages/3.8/bioc/src/contrib/rsbml_2.40.0.tar.gz
15:08:37 BIOCONDA INFO creating recipes/bioconductor-rsbml
15:08:37 BIOCONDA INFO BioConductor dependency: name="BiocGenerics" version=">=0.28.0,<0.30.0"
15:08:37 BIOCONDA INFO            R dependency: name="R" version=">=2.6.0"
15:08:37 BIOCONDA INFO BioConductor dependency: name="graph" version=">=1.60.0,<1.62.0"
15:08:37 BIOCONDA WARNING The 'SystemRequirements' libsbml (==5.10.2) are needed by the recipe for the package to work as intended.
15:08:37 BIOCONDA INFO Wrote recipe in recipes/bioconductor-rsbml
```